### PR TITLE
Failure alerts

### DIFF
--- a/app/code/community/Aoe/DbRetry/Model/Cron.php
+++ b/app/code/community/Aoe/DbRetry/Model/Cron.php
@@ -10,7 +10,7 @@ class Aoe_DbRetry_Model_Cron
     const DATE_FORMAT = 'yyyy-MM-ddThh'; // ISO_8601, but without the minutes and seconds
 
     protected $_alertThreshold;
-    protected $_occurenceCount;
+    protected $_occurrenceCount;
     protected $_fullErrorFilePath;
     protected $_currentHourForLogs;
     protected $_date;
@@ -23,7 +23,7 @@ class Aoe_DbRetry_Model_Cron
             return;
         }
 
-        $count = (int)$this->_getOccurenceCount();
+        $count = (int)$this->_getOccurrenceCount();
         if ($count > $threshold) {
             $this->_sendAlert();
         }
@@ -37,16 +37,16 @@ class Aoe_DbRetry_Model_Cron
         return $this->_alertThreshold;
     }
 
-    protected function _getOccurenceCount()
+    protected function _getOccurrenceCount()
     {
-        if (is_null($this->_occurenceCount)) {
+        if (is_null($this->_occurrenceCount)) {
             $file = $this->_getFullErrorFilePath();
             $currentHourForLogs = $this->_getCurrentHourForLogs();
             $lines = preg_grep('/'.$currentHourForLogs.'/', file($file)); // Get the lines from the past hour
             $lines = preg_grep('/'.self::ERROR_IDENTIFIER.'/', $lines); // Only get the lines that identify a new error
-            $this->_occurenceCount = count($lines);
+            $this->_occurrenceCount = count($lines);
         }
-        return $this->_occurenceCount;
+        return $this->_occurrenceCount;
     }
 
     protected function _getFullErrorFilePath()
@@ -80,7 +80,7 @@ class Aoe_DbRetry_Model_Cron
         $mail->setFrom(Mage::getStoreConfig('trans_email/ident_general/email'));
         $mail->addTo(Mage::getConfig()->getNode(self::ALERT_RECIPIENTS_CONFIG_NODE));
         $mail->setSubject(Mage::getStoreConfig('general/store_information/name') . ' - DB Retry Alert');
-        $mail->setBodyText("There have been " . $this->_getOccurenceCount() . " unrecoverable errors in the past hour");
+        $mail->setBodyText("There have been " . $this->_getOccurrenceCount() . " unrecoverable errors in the past hour");
         $mail->send();
     }
 

--- a/app/code/community/Aoe/DbRetry/Model/Cron.php
+++ b/app/code/community/Aoe/DbRetry/Model/Cron.php
@@ -1,0 +1,90 @@
+<?php
+
+class Aoe_DbRetry_Model_Cron
+{
+
+    const ALERT_THRESHOLD_CONFIG_NODE = 'global/resources/aoe_dbretry_alert_threshold';
+    const ALERT_RECIPIENTS_CONFIG_NODE = 'global/resources/aoe_dbretry_alert_recipients';
+    const ERROR_IDENTIFIER = 'Unrecoverable Error';
+    const ERROR_FILE_NAME = 'aoe_dbretry_unrecoverable.log';
+    const DATE_FORMAT = 'yyyy-MM-ddThh'; // ISO_8601, but without the minutes and seconds
+
+    protected $_alertThreshold;
+    protected $_occurenceCount;
+    protected $_fullErrorFilePath;
+    protected $_currentHourForLogs;
+    protected $_date;
+    protected $_alertRecipients;
+
+    public function checkAlert()
+    {
+        $threshold = (int)$this->_getAlertThreshold();
+        if (!$threshold) {
+            return;
+        }
+
+        $count = (int)$this->_getOccurenceCount();
+        if ($count > $threshold) {
+            $this->_sendAlert();
+            Mage::log("Unrecoverable - Sending an alert");
+        } else {
+            echo "Didnt need to send an alert, woo-hoo!";
+        }
+    }
+
+    protected function _getAlertThreshold()
+    {
+        if (is_null($this->_alertThreshold)) {
+            $this->_alertThreshold = Mage::getConfig()->getNode(self::ALERT_THRESHOLD_CONFIG_NODE);
+        }
+        return $this->_alertThreshold;
+    }
+
+    protected function _getOccurenceCount()
+    {
+        if (is_null($this->_occurenceCount)) {
+            $file = $this->_getFullErrorFilePath();
+            $currentHourForLogs = $this->_getCurrentHourForLogs();
+            $lines = preg_grep('/'.$currentHourForLogs.'/', file($file)); // Get the lines from the past hour
+            $lines = preg_grep('/'.self::ERROR_IDENTIFIER.'/', $lines); // Only get the lines that identify a new error
+            $this->_occurenceCount = count($lines);
+        }
+        return $this->_occurenceCount;
+    }
+
+    protected function _getFullErrorFilePath()
+    {
+        if (is_null($this->_fullErrorFilePath)) {
+            $this->_fullErrorFilePath = Mage::getBaseDir('var') . DS . 'log' . DS . self::ERROR_FILE_NAME;
+        }
+        return $this->_fullErrorFilePath;
+    }
+
+    protected function _getCurrentHourForLogs()
+    {
+        if (is_null($this->_currentHourForLogs)) {
+            $date = $this->_getDate();
+            $this->_currentHourForLogs = $date->get(self::DATE_FORMAT);
+        }
+        return $this->_currentHourForLogs;
+    }
+
+    protected function _getDate()
+    {
+        if (is_null($this->_date)) {
+            $this->_date = new Zend_Date();
+        }
+        return $this->_date;
+    }
+
+    protected function _sendAlert()
+    {
+        $mail = new Zend_Mail();
+        $mail->setFrom(Mage::getStoreConfig('trans_email/ident_general/email'));
+        $mail->addTo(Mage::getConfig()->getNode(self::ALERT_RECIPIENTS_CONFIG_NODE));
+        $mail->setSubject(Mage::getStoreConfig('general/store_information/name') . ' - DB Retry Alert');
+        $mail->setBodyText("There have been " . $this->_getOccurenceCount() . " unrecoverable errors in the past hour");
+        $mail->send();
+    }
+
+}

--- a/app/code/community/Aoe/DbRetry/Model/Cron.php
+++ b/app/code/community/Aoe/DbRetry/Model/Cron.php
@@ -26,9 +26,6 @@ class Aoe_DbRetry_Model_Cron
         $count = (int)$this->_getOccurenceCount();
         if ($count > $threshold) {
             $this->_sendAlert();
-            Mage::log("Unrecoverable - Sending an alert");
-        } else {
-            echo "Didnt need to send an alert, woo-hoo!";
         }
     }
 

--- a/app/code/community/Aoe/DbRetry/Resource/Db/Pdo/Mysql/Adapter.php
+++ b/app/code/community/Aoe/DbRetry/Resource/Db/Pdo/Mysql/Adapter.php
@@ -52,7 +52,7 @@ class Aoe_DbRetry_Resource_Db_Pdo_Mysql_Adapter extends Magento_Db_Adapter_Pdo_M
                             continue;
                         }
                     }
-                    if ($connection->_config['aoe_dbretry_alert_threshold']) {
+                    if (Mage::getConfig()->getNode('global/resources/aoe_dbretry_alert_threshold')) {
                         Mage::log("Unrecoverable Error", Zend_Log::ERR, 'aoe_dbretry_unrecoverable.log', true);
                         Mage::log($e->__toString(), Zend_Log::ERR, 'aoe_dbretry_unrecoverable.log', true);
                     }

--- a/app/code/community/Aoe/DbRetry/Resource/Db/Pdo/Mysql/Adapter.php
+++ b/app/code/community/Aoe/DbRetry/Resource/Db/Pdo/Mysql/Adapter.php
@@ -52,7 +52,10 @@ class Aoe_DbRetry_Resource_Db_Pdo_Mysql_Adapter extends Magento_Db_Adapter_Pdo_M
                             continue;
                         }
                     }
-
+                    if ($connection->_config['aoe_dbretry_alert_threshold']) {
+                        Mage::log("Unrecoverable Error", Zend_Log::ERR, 'aoe_dbretry_unrecoverable.log', true);
+                        Mage::log($e->__toString(), Zend_Log::ERR, 'aoe_dbretry_unrecoverable.log', true);
+                    }
                     throw $e;
                 }
             }

--- a/app/code/community/Aoe/DbRetry/etc/config.xml
+++ b/app/code/community/Aoe/DbRetry/etc/config.xml
@@ -16,5 +16,20 @@
                 </types>
             </connection>
         </resource>
+        <models>
+            <aoe_dbretry>
+                <class>Aoe_DbRetry_Model</class>
+            </aoe_dbretry>
+        </models>
     </global>
+    <crontab>
+        <jobs>
+            <aoe_dbretry_alert>
+                <schedule><cron_expr>59 * * * *</cron_expr></schedule>
+                <run>
+                    <model>aoe_dbretry/cron::checkAlert</model>
+                </run>
+            </aoe_dbretry_alert>
+        </jobs>
+    </crontab>
 </config>


### PR DESCRIPTION
This is the feature that I outlined in #3.

Since configuration for this module is set up through `local.xml` I set this up that way as well, rather than introducing an area in the system configuration. E.g.

``` xml
<config>
  <global>
    <resources>
      <aoe_dbretry_alert_threshold>10</aoe_dbretry_alert_threshold>
      <aoe_dbretry_alert_recipients>myemail@example.com</aoe_dbretry_alert_recipients>
```

I've tried to keep this as lightweight as possible, but it does require introducing a new cron job. I understand if you feel this is out of scope for this project, but it is a requirement for one of our clients, so I figured I'd see if you would incorporate it upstream.
